### PR TITLE
Fix Linker Errors in New I2CDevice Class

### DIFF
--- a/lib/i2c_device.cpp
+++ b/lib/i2c_device.cpp
@@ -1,17 +1,20 @@
 #include "i2c_device.hpp"
 
-I2CDevice::I2CDevice(int address_, std::string name_){
+I2CDevice::I2CDevice(int address_, std::string name_)
+{
   name = name_;
   address = address_;
   bus = open_smbus();
-  //bus = smbus(1); // open i2c bus 1
+  // bus = smbus(1); // open i2c bus 1
 }
 
 // TODO: currently causing a linker error
-int I2CDevice::open_smbus(){
+int
+I2CDevice::open_smbus()
+{
   int file;
   char* filename = "/dev/i2c-1";
-  if ((file = open(filename, O_RDWR)) < 0){
+  if ((file = open(filename, O_RDWR)) < 0) {
     /* ERROR HANDLING: you can check errno to see what went wrong */
     perror("Failed to open the i2c bus");
     exit(1);
@@ -20,30 +23,35 @@ int I2CDevice::open_smbus(){
   return file;
 }
 
-__s32 I2CDevice::read(__u8 register_){
+__s32
+I2CDevice::read(__u8 register_)
+{
   // initiate communication with peripheral sensor
-  if (ioctl(bus, I2C_SLAVE, address) < 0){
+  if (ioctl(bus, I2C_SLAVE, address) < 0) {
     /* ERROR HANDLING; you can check errno to see what went wrong */
     exit(1);
   }
 
-  //read 1 byte from register
-  return i2c_smbus_read_word_data(address, register);
-
+  // read 1 byte from register
+  return i2c_smbus_read_word_data(address, register_);
 }
 
-std::vector<__s32> I2CDevice::read_block(__u8 register_, int num){
+std::vector<__s32>
+I2CDevice::read_block(__u8 register_, int num)
+{
   // data to read
   std::vector<__s32> data;
 
-  for (int i=0; i<num; i++)
-    data.push_back(read(register_+i));
+  for (int i = 0; i < num; i++)
+    data.push_back(read(register_ + i));
 
   return data;
 }
 
-__s32 I2CDevice::write(__u8 register_, __u8 data){
-  return i2c_smbus_write_byte_data(address, register_, data)
+__s32
+I2CDevice::write(__u8 register_, __u8 data)
+{
+  return i2c_smbus_write_byte_data(address, register_, data);
 }
 
 /*    PYTHON CODE THAT NEEDS TO BE CONVERTED TO C++ ABOVE:

--- a/lib/i2c_device.hpp
+++ b/lib/i2c_device.hpp
@@ -3,8 +3,12 @@
 #include <string>
 #include <vector>
 #include <fcntl.h>
+#include <sys/ioctl.h>
+
+extern "C" {
 #include <linux/i2c-dev.h>
 #include <i2c/smbus.h>
+}
 
 class I2CDevice {
 /*


### PR DESCRIPTION
Some very small fixes to ensure that the new `I2CDevice` class can be linked on a linux system. Tested using `clang++`, probably worth trying with `g++` if that is what the team is planning on using, though I don't suspect it will be an issue.